### PR TITLE
feat: redireciona para /continuar-comprando após contato

### DIFF
--- a/src/components/ui/ContactModal.tsx
+++ b/src/components/ui/ContactModal.tsx
@@ -31,6 +31,7 @@ Gostaria de mais informações sobre como proceder com a compra.`;
 
     const whatsappUrl = `https://wa.me/5511991795436?text=${encodeURIComponent(message)}`;
     window.open(whatsappUrl, '_blank');
+    window.location.href = '/continuar-comprando';
     onOpenChange(false);
   };
 

--- a/src/pages/ContinuarComprando.tsx
+++ b/src/pages/ContinuarComprando.tsx
@@ -337,10 +337,10 @@ export default function ContinuarComprando() {
             className="mb-3"
             items={[
               { name: 'Início', url: '/' },
-              { name: 'Comprar Backlinks', url: '/comprar-backlinks' },
+              { name: 'Continuar Comprando', url: '/continuar-comprando' },
             ]}
           />
-          <h1 className="text-4xl font-bold mb-6">Comprar Backlinks em Grandes Portais</h1>
+          <h1 className="text-4xl font-bold mb-6">Continue Comprando</h1>
           {categories.length > 0 && (
             <section className="mb-6">
               <div className="grid grid-cols-2 md:grid-cols-4 gap-2">


### PR DESCRIPTION
Adiciona um redirecionamento para a página /continuar-comprando sempre que o usuário clica no botão "Contatar WhatsApp" no modal de contato.

Isso melhora a experiência do usuário, guiando-o para uma página de listagem de produtos após iniciar o contato, em vez de deixá-lo na mesma página com o modal fechado.

Adicionalmente, o conteúdo da página /continuar-comprando foi atualizado para refletir seu propósito, com o título e breadcrumbs corrigidos.