### PR TITLE
Correção da estilização do editor de texto SEO

### DIFF
--- a/src/components/ui/rich-text-editor.tsx
+++ b/src/components/ui/rich-text-editor.tsx
@@ -21,7 +21,7 @@ function markdownToHtml(markdown: string): string {
   if (!markdown) return "";
   
   // Check if it's already HTML
-  if (markdown.includes("<p>") || markdown.includes("<h") || markdown.includes("<ul>")) {
+  if (markdown.includes("<p>") || markdown.includes("<h") || markdown.includes("<ul>") || markdown.includes("<ol") || markdown.includes("<li>") || markdown.includes("<blockquote")) {
     return markdown;
   }
   
@@ -104,13 +104,14 @@ export function RichTextEditor({
     editorProps: {
       attributes: {
         class: cn(
-          "prose prose-sm max-w-none dark:prose-invert focus:outline-none",
+          "prose prose-sm sm:prose-base max-w-none dark:prose-invert focus:outline-none min-h-[inherit]",
           "prose-headings:font-semibold prose-headings:text-foreground",
           "prose-p:text-foreground prose-p:leading-relaxed",
           "prose-a:text-primary prose-a:underline",
           "prose-strong:text-foreground prose-strong:font-semibold",
           "prose-ul:list-disc prose-ol:list-decimal",
-          "prose-blockquote:border-l-4 prose-blockquote:border-primary prose-blockquote:pl-4 prose-blockquote:italic"
+          "prose-blockquote:border-l-4 prose-blockquote:border-primary prose-blockquote:pl-4 prose-blockquote:italic",
+          "font-sans"
         ),
       },
     },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -111,5 +111,5 @@ export default {
 				}
 			}
 		},
-	plugins: [require("tailwindcss-animate")],
+	plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],
 } satisfies Config;


### PR DESCRIPTION
Identifiquei que o problema onde títulos e listas não eram exibidos corretamente no editor de "Conteúdo SEO" era causado pela ausência do plugin de tipografia do Tailwind CSS. Em projetos Tailwind, os estilos padrão do navegador são removidos (reset), e o uso de tags semânticas como <h1> ou <ul> requer o plugin de tipografia para serem visualmente distintos.

Realizei as seguintes alterações:
1. Instalei e configurei o plugin `@tailwindcss/typography` no `tailwind.config.ts`.
2. Atualizei o componente `RichTextEditor` para aplicar as classes `prose` corretamente, garantindo que títulos, subtítulos e listas tenham o tamanho e estilo esperados.
3. Refinei a lógica de carregamento de conteúdo para garantir compatibilidade entre o formato salvo e o editor.
4. Verifiquei visualmente as mudanças através de testes automatizados com screenshots, confirmando que agora os títulos aparecem destacados e as listas exibem marcadores.

---
*PR created automatically by Jules for task [6166201690238604117](https://jules.google.com/task/6166201690238604117) started by @marconez777*