### PR TITLE
Blog Editor SEO Fields and Image Upload Fix

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -289,6 +289,7 @@ export type Database = {
           id: string
           published: boolean | null
           published_at: string | null
+          seo_title: string | null
           slug: string
           tags: string[] | null
           title: string
@@ -304,6 +305,7 @@ export type Database = {
           id?: string
           published?: boolean | null
           published_at?: string | null
+          seo_title?: string | null
           slug: string
           tags?: string[] | null
           title: string
@@ -319,6 +321,7 @@ export type Database = {
           id?: string
           published?: boolean | null
           published_at?: string | null
+          seo_title?: string | null
           slug?: string
           tags?: string[] | null
           title?: string

--- a/src/pages/AdminBlogNew.tsx
+++ b/src/pages/AdminBlogNew.tsx
@@ -29,6 +29,7 @@ export default function AdminBlogNew() {
 
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
+  const [seoTitle, setSeoTitle] = useState("");
   const [seoDesc, setSeoDesc] = useState("");
   const [slug, setSlug] = useState("");
   const [featuredUrl, setFeaturedUrl] = useState<string | null>(null);
@@ -82,6 +83,7 @@ export default function AdminBlogNew() {
       } else if (data) {
         setTitle(data.title);
         setContent(data.content || "");
+        setSeoTitle(data.seo_title || "");
         setSeoDesc(data.excerpt || "");
         setSlug(data.slug);
         setFeaturedUrl(data.cover_image);
@@ -100,8 +102,16 @@ export default function AdminBlogNew() {
   async function uploadToBucket(file: File): Promise<string> {
     const ext = file.name.split(".").pop()?.toLowerCase() || "jpg";
     const path = `posts/${new Date().getFullYear()}/${(new Date().getMonth()+1).toString().padStart(2,'0')}/${crypto.randomUUID()}.${ext}`;
+
     const { error } = await supabase.storage.from('blog').upload(path, file, { upsert: false, contentType: file.type });
-    if (error) throw error;
+
+    if (error) {
+      if (error.message.includes("Bucket not found")) {
+        throw new Error("O bucket 'blog' não foi encontrado no seu Supabase Storage. Por favor, crie um bucket público chamado 'blog'.");
+      }
+      throw error;
+    }
+
     const { data } = supabase.storage.from('blog').getPublicUrl(path);
     return data.publicUrl;
   }
@@ -140,6 +150,7 @@ export default function AdminBlogNew() {
   const resetForm = () => {
     setTitle("");
     setContent("");
+    setSeoTitle("");
     setSeoDesc("");
     setSlug("");
     setFeaturedUrl(null);
@@ -161,6 +172,7 @@ export default function AdminBlogNew() {
         title: title.trim(),
         content: content,
         cover_image: featuredUrl,
+        seo_title: seoTitle.trim() || undefined,
         excerpt: seoDesc || undefined,
         slug: slugify(slug),
         published: true,
@@ -229,12 +241,58 @@ export default function AdminBlogNew() {
 
         <section className="grid grid-cols-1 gap-6">
           <div className="grid gap-2">
-            <label className="text-sm font-medium">Título do Post</label>
-            <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Digite o título" />
+            <label className="text-sm font-medium">Título do Post (Exibição no Site)</label>
+            <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Digite o título que aparecerá no post" />
+          </div>
+
+          {/* Seção SEO */}
+          <div className="rounded-lg border bg-card p-6 space-y-4">
+            <h3 className="text-lg font-medium border-b pb-2">Configurações de SEO</h3>
+
+            <div className="grid gap-2">
+              <label className="text-sm font-medium">Título SEO (Aba do Navegador)</label>
+              <Input
+                value={seoTitle}
+                onChange={(e) => setSeoTitle(e.target.value)}
+                placeholder={title || "Digite o título para SEO"}
+              />
+              <p className="text-xs text-muted-foreground">Se vazio, usará o Título do Post.</p>
+            </div>
+
+            <div className="grid gap-2">
+              <label className="text-sm font-medium">Descrição SEO (Meta Description)</label>
+              <Textarea
+                value={seoDesc}
+                onChange={(e) => setSeoDesc(e.target.value)}
+                rows={3}
+                placeholder="Resumo do post para buscadores (Google)"
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <label className="text-sm font-medium">URL SEO (Slug)</label>
+              <Input value={slug} onChange={(e) => setSlug(e.target.value)} placeholder={autoSlug || "minha-url-seo"} />
+              <p className="text-xs text-muted-foreground">URL final: {window.location.origin}/blog/{slugify(slug || autoSlug)}</p>
+            </div>
           </div>
 
           <div className="grid gap-2">
-            <label className="text-sm font-medium">Texto do Post</label>
+            <label className="text-sm font-medium">Imagem em destaque do Post</label>
+            <div className="flex items-center gap-2">
+              <input ref={hiddenFeaturedInput} type="file" accept="image/*" onChange={handleFeaturedUpload} />
+            </div>
+            {featuredUrl && (
+              <img src={featuredUrl} alt="Imagem em destaque do post" className="max-h-48 rounded-md border object-contain" />
+            )}
+            {!featuredUrl && (
+              <div className="h-32 w-full bg-muted flex items-center justify-center rounded-md border border-dashed">
+                <p className="text-sm text-muted-foreground">Nenhuma imagem selecionada</p>
+              </div>
+            )}
+          </div>
+
+          <div className="grid gap-2">
+            <label className="text-sm font-medium">Conteúdo do Post</label>
             <input
               ref={hiddenInlineImageInput}
               type="file"
@@ -252,26 +310,6 @@ export default function AdminBlogNew() {
                 hiddenInlineImageInput.current?.click();
               }}
             />
-          </div>
-
-          <div className="grid gap-2">
-            <label className="text-sm font-medium">Imagem em destaque do Post</label>
-            <div className="flex items-center gap-2">
-              <input ref={hiddenFeaturedInput} type="file" accept="image/*" onChange={handleFeaturedUpload} />
-            </div>
-            {featuredUrl && (
-              <img src={featuredUrl} alt="Imagem em destaque do post" className="max-h-48 rounded-md border object-contain" />
-            )}
-          </div>
-
-          <div className="grid gap-2">
-            <label className="text-sm font-medium">Descrição SEO (Excerpt)</label>
-            <Textarea value={seoDesc} onChange={(e) => setSeoDesc(e.target.value)} rows={3} placeholder="Até ~160 caracteres" />
-          </div>
-          <div className="grid gap-2">
-            <label className="text-sm font-medium">URL SEO (Slug)</label>
-            <Input value={slug} onChange={(e) => setSlug(e.target.value)} placeholder={autoSlug || "minha-url-seo"} />
-            <p className="text-xs text-muted-foreground">URL final: {window.location.origin}/blog/{slugify(slug || autoSlug)}</p>
           </div>
         </section>
       </main>

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -15,6 +15,7 @@ import { supabase } from "@/integrations/supabase/client";
 interface DbPost {
   id: string;
   title: string;
+  seo_title: string | null;
   slug: string;
   content: string | null;
   cover_image: string | null;
@@ -35,7 +36,7 @@ function usePost(slug?: string) {
       setLoading(true);
       const { data, error } = await supabase
         .from("posts")
-        .select("id,title,slug,content,cover_image,excerpt,created_at,updated_at,category")
+        .select("id,title,seo_title,slug,content,cover_image,excerpt,created_at,updated_at,category")
         .eq("slug", slug)
         .eq("published", true)
         .maybeSingle();
@@ -104,7 +105,7 @@ export default function BlogPost() {
   return (
     <>
       <SEOHead
-        title={post.title}
+        title={post.seo_title || post.title}
         description={post.excerpt || ""}
         canonicalUrl={postUrl}
         keywords="blog seo, marketing digital, backlinks, link building"
@@ -115,7 +116,7 @@ export default function BlogPost() {
       <StructuredData
         type="article"
         data={{
-          headline: post.title,
+          headline: post.seo_title || post.title,
           description: post.excerpt,
           author: "MK Art SEO",
           datePublished: post.created_at,


### PR DESCRIPTION
I have implemented the requested changes to the blog post editor and the public blog post page.

Key changes:
1. **SEO Section**: A new "Configurações de SEO" section was added to the editor, located above the rich text content area. It includes fields for 'Título SEO' (new), 'Descrição SEO' (using the existing excerpt field), and 'URL SEO' (slug).
2. **SEO Metadata**: The public blog post page now uses the 'seo_title' for the browser tab and search engine results if provided, falling back to the main post title otherwise.
3. **Image Upload Fix**: I've improved the error handling for image uploads. If the 'blog' bucket is missing in Supabase (which was the cause of the reported error), the editor will now provide a clear message asking to create it.
4. **UI Improvements**: Added a placeholder in the editor when no featured image is selected to clarify where it will appear.

I have verified the layout changes visually using a Playwright screenshot.

---
*PR created automatically by Jules for task [1835244129130311903](https://jules.google.com/task/1835244129130311903) started by @marconez777*