### PR TITLE
Update Resend sender email and add configuration instructions

### DIFF
--- a/INSTRUCOES_RESEND.md
+++ b/INSTRUCOES_RESEND.md
@@ -1,0 +1,32 @@
+# Instruções para Configuração do Resend no Lovable / Supabase
+
+Para que o envio de e-mails funcione corretamente, você precisa adicionar a chave de API do Resend nas variáveis de ambiente do seu projeto no Lovable Cloud (que utiliza o Supabase).
+
+Siga os passos abaixo:
+
+1.  Acesse o painel do **Lovable** (ou Supabase, se tiver acesso direto).
+2.  No menu lateral esquerdo, clique em **Secrets** (ícone de chave), conforme mostrado na imagem que você enviou.
+3.  Você verá uma tela para gerenciar as "Environment Variables" ou "Secrets".
+4.  Clique no botão para adicionar um novo segredo (geralmente **"New Secret"** ou **"Add Secret"**).
+5.  Preencha os campos da seguinte forma:
+    *   **Name (Nome):** `RESEND_API_KEY`
+    *   **Value (Valor):** `Insira sua chave API aqui` (começa com `re_`)
+6.  Salve a alteração.
+
+### Verificação
+
+Após adicionar a chave, o sistema redistribuirá automaticamente as Edge Functions com a nova configuração. Isso pode levar alguns segundos.
+
+### Configurações Realizadas no Código
+
+Todas as funções de envio de e-mail foram atualizadas para utilizar o remetente:
+*   **Nome:** MK Art SEO / MK Art Agência
+*   **Email:** `contato@mkart.com.br`
+
+As funções alteradas foram:
+*   `send-contact-email` (Formulário de contato)
+*   `send-payment-email` (Envio de dados PIX)
+*   `send-activation-email` (Ativação de conta)
+*   `send-guest-post-list` (Envio de lista de guest posts)
+*   `send-order-status-email` (Notificação de status do pedido)
+*   `send-reset-password-email` (Redefinição de senha)

--- a/supabase/functions/send-activation-email/index.ts
+++ b/supabase/functions/send-activation-email/index.ts
@@ -37,7 +37,7 @@ const handler = async (req: Request): Promise<Response> => {
     );
 
     const emailResponse = await resend.emails.send({
-      from: "MK Art SEO <noreply@mkart.com.br>",
+      from: "MK Art SEO <contato@mkart.com.br>",
       to: [email],
       subject: "Ative sua conta - MK Art SEO",
       html,

--- a/supabase/functions/send-contact-email/index.ts
+++ b/supabase/functions/send-contact-email/index.ts
@@ -26,7 +26,7 @@ const handler = async (req: Request): Promise<Response> => {
 
     // Send email to company
     const companyEmailResponse = await resend.emails.send({
-      from: "Contato MK Art <onboarding@resend.dev>",
+      from: "Contato MK Art <contato@mkart.com.br>",
       to: ["contato@mkart.com.br"],
       subject: `Nova mensagem de contato - ${name}`,
       html: `
@@ -40,7 +40,7 @@ const handler = async (req: Request): Promise<Response> => {
 
     // Send confirmation email to user
     const userEmailResponse = await resend.emails.send({
-      from: "MK Art Agência <onboarding@resend.dev>",
+      from: "MK Art Agência <contato@mkart.com.br>",
       to: [email],
       subject: "Recebemos sua mensagem!",
       html: `

--- a/supabase/functions/send-guest-post-list/index.ts
+++ b/supabase/functions/send-guest-post-list/index.ts
@@ -34,7 +34,7 @@ const handler = async (req: Request): Promise<Response> => {
     );
 
     const emailResponse = await resend.emails.send({
-      from: "MK Art SEO <noreply@mkart.com.br>",
+      from: "MK Art SEO <contato@mkart.com.br>",
       to: [email],
       subject: "🎉 Sua Lista de 30 Sites para Guest Post DR 20-90 está aqui!",
       html,

--- a/supabase/functions/send-order-status-email/index.ts
+++ b/supabase/functions/send-order-status-email/index.ts
@@ -48,7 +48,7 @@ const handler = async (req: Request): Promise<Response> => {
     const subject = `${statusSubjects[status]} - Pedido #${shortOrderId}`;
 
     const emailResponse = await resend.emails.send({
-      from: "MK Art SEO <noreply@mkart.com.br>",
+      from: "MK Art SEO <contato@mkart.com.br>",
       to: [email],
       subject,
       html,

--- a/supabase/functions/send-payment-email/index.ts
+++ b/supabase/functions/send-payment-email/index.ts
@@ -40,7 +40,7 @@ const handler = async (req: Request): Promise<Response> => {
     );
 
     const emailResponse = await resend.emails.send({
-      from: "MK Art SEO <noreply@mkart.com.br>",
+      from: "MK Art SEO <contato@mkart.com.br>",
       to: [email],
       subject: `PIX para pagamento - Pedido #${order_id.slice(0, 8).toUpperCase()}`,
       html,

--- a/supabase/functions/send-reset-password-email/index.ts
+++ b/supabase/functions/send-reset-password-email/index.ts
@@ -35,7 +35,7 @@ const handler = async (req: Request): Promise<Response> => {
     );
 
     const emailResponse = await resend.emails.send({
-      from: "MK Art SEO <noreply@mkart.com.br>",
+      from: "MK Art SEO <contato@mkart.com.br>",
       to: [email],
       subject: "Redefinir senha - MK Art SEO",
       html,


### PR DESCRIPTION
Updated all Supabase Edge Functions to use 'contato@mkart.com.br' as the sender email address.
Created `INSTRUCOES_RESEND.md` with instructions for the user to add the `RESEND_API_KEY` to their Lovable/Supabase Secrets.

---
*PR created automatically by Jules for task [10904121059414723677](https://jules.google.com/task/10904121059414723677) started by @marconez777*